### PR TITLE
new: internal link update

### DIFF
--- a/src/Classify/init.lua
+++ b/src/Classify/init.lua
@@ -86,7 +86,7 @@ function Classify.meta.__index(self: table, key: string): any
             elseif property.internal then
                 local nodes = {}
 
-                for node in property.internal:gmatch("([^.]+)") do
+                for node in property.internal:gmatch('([^.]+)') do
                     table.insert(nodes, node)
                 end
 
@@ -125,12 +125,14 @@ function Classify.meta.__newindex(self: table, key: string, value: any): nil
         if property then
             if property.internal then
                 local nodes = {}
-                for node in property.internal:gmatch("([^.]+)") do
+                for node in property.internal:gmatch('([^.]+)') do
                     table.insert(nodes, node)
                 end
+
                 if nodes and #nodes > 0 then
                     local prop = self
                     local target = nodes[#nodes]
+
                     for index, node in ipairs(nodes) do
                         if next(nodes, index) ~= nil then
                             prop = rawget(prop, node)

--- a/src/Classify/init.lua
+++ b/src/Classify/init.lua
@@ -84,18 +84,19 @@ function Classify.meta.__index(self: table, key: string): any
             elseif property.bind and property.target then
                 return property.target(self)[property.bind]
             elseif property.internal then
-                local nodes = {}
-
+                local nodes = { }
+                
                 for node in property.internal:gmatch('([^.]+)') do
                     table.insert(nodes, node)
                 end
-
+                
                 if nodes and #nodes > 0 then
                     local prop = self
+                    
                     for _, node in ipairs(nodes) do
                         prop = rawget(prop, node)
                     end
-
+                    
                     return prop
                 else
                     return rawget(self, property.internal)
@@ -128,17 +129,17 @@ function Classify.meta.__newindex(self: table, key: string, value: any): nil
                 for node in property.internal:gmatch('([^.]+)') do
                     table.insert(nodes, node)
                 end
-
+                
                 if nodes and #nodes > 0 then
                     local prop = self
                     local target = nodes[#nodes]
-
+                    
                     for index, node in ipairs(nodes) do
                         if next(nodes, index) ~= nil then
                             prop = rawget(prop, node)
                         end
                     end
-
+                    
                     rawset(prop, target, value)
                     success = true
                     p_signal = true

--- a/src/Classify/init.lua
+++ b/src/Classify/init.lua
@@ -84,7 +84,22 @@ function Classify.meta.__index(self: table, key: string): any
             elseif property.bind and property.target then
                 return property.target(self)[property.bind]
             elseif property.internal then
-                return rawget(self, property.internal)
+                local nodes = {}
+
+                for node in property.internal:gmatch("([^.]+)") do
+                    table.insert(nodes, node)
+                end
+
+                if nodes and #nodes > 0 then
+                    local prop = self
+                    for _, node in ipairs(nodes) do
+                        prop = rawget(prop, node)
+                    end
+
+                    return prop
+                else
+                    return rawget(self, property.internal)
+                end
             else
                 err(MESSAGES.NOREAD_PROPERTY, key, rawget(self, '__classname'))
             end
@@ -109,9 +124,27 @@ function Classify.meta.__newindex(self: table, key: string, value: any): nil
         
         if property then
             if property.internal then
-                rawset(self, property.internal, value)
-                success = true
-                p_signal = true
+                local nodes = {}
+                for node in property.internal:gmatch("([^.]+)") do
+                    table.insert(nodes, node)
+                end
+                if nodes and #nodes > 0 then
+                    local prop = self
+                    local target = nodes[#nodes]
+                    for index, node in ipairs(nodes) do
+                        if next(nodes, index) ~= nil then
+                            prop = rawget(prop, node)
+                        end
+                    end
+
+                    rawset(prop, target, value)
+                    success = true
+                    p_signal = true
+                else
+                    rawset(self, property.internal, value)
+                    success = true
+                    p_signal = true
+                end
             end
             
             if property.set then


### PR DESCRIPTION
### Plucking
Currently "**internal**" properties can only be tied to a property that is directly a child of the class, this change supports plucking a string to link properties to keys that are **deeper**.

Usage Example:

```lua
local self = Classify({})
self._settings = {}
self._settings.Data = {}
self._settings.Data.Key = "generic key"

self.__properties = {
     CustomProperty = { _internal = "_settings.Data.Key" } -- will now reference (self._settings.Data.Key)
}
```
